### PR TITLE
polybar-i3: Set the foreground-color of label-focus in the i3 module to ${color.focus}

### DIFF
--- a/.config/polybar-i3/shapes/modules.ini
+++ b/.config/polybar-i3/shapes/modules.ini
@@ -566,7 +566,7 @@ label-mode-background = #e60053
 ;   %output%
 ; Default: %icon%  %name%
 label-focused = %icon%
-label-focused-foreground = ${color.foreground}
+label-focused-foreground = ${color.focus}
 label-focused-background = ${color.background}
 label-focused-underline = ${color.focus}
 label-focused-padding = 2


### PR DESCRIPTION
Closes #28 